### PR TITLE
Require pixi v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "render"
   ],
   "peerDependencies":{
-    "pixi.js": "^3.0.0"
+    "pixi.js": "^3.0.2"
   },
   "dependencies": {
     "async": "^0.9.0",


### PR DESCRIPTION
After #21 and #22 are merged, PIXI v3.0.2 will be required for this module to work. After merging those other PRs, this one should be merged as well to inform users of that dep.

3.0.2 will be the version that goes live with the changes I mentioned in those 2 PRs.