### PR TITLE
Fix extra slash in url address when trying to load image asset.

### DIFF
--- a/src/SpineRuntime/Atlas.js
+++ b/src/SpineRuntime/Atlas.js
@@ -5,7 +5,7 @@ spine.AtlasRegion = require('./AtlasRegion');
 
 spine.Atlas = function (atlasText, baseUrl, crossOrigin)
 {
-    if (baseUrl && baseUrl.indexOf('/') !== baseUrl.length)
+    if (baseUrl && baseUrl.lastIndexOf('/') !== (baseUrl.length-1))
     {
         baseUrl += '/';
     }


### PR DESCRIPTION
Hi,

I was checking Spine animations recently and it was working perfectly locally but when I was trying to load it from Amazon S3 I was having problem with loading image. After some investigation I noticed double slash in my image url. Going deeper I end up in here:
![doubleslash](https://cloud.githubusercontent.com/assets/2122619/10245880/f502cada-6903-11e5-9d0d-753ee1f098ef.png)


By quick look at it it's quite obvious that we'll always have extra slash if assets are more than one folder deep. So we probably should use "lastIndexOf" instead of "indexOf".
2nd thing it's always false anyway, because last character index is length-1 anyway...


Recommended fix:
src/SpineRuntime/Atlas.js

instead of
if (baseUrl && baseUrl.indexOf('/') !== baseUrl.length)

it should be
if (baseUrl && baseUrl.lastIndexOf('/') !== (baseUrl.length-1))


Best Regards