### PR TITLE
Added bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "pixi-spine",
+  "version": "1.0.18",
+  "main": "bin/pixi-spine.min.js",
+  "dependencies": {
+    "pixi.js": "*"
+  },
+  "ignore": [
+    "gpupatch",
+    "gulp",
+    "src",
+    "test",
+    ".editorconfig",
+    ".gitignore",
+    ".jshintrc",
+    "docs.json",
+    "gulpfile.js",
+    "jsdoc_docs_conf.json",
+    "package.json"
+  ]
+}


### PR DESCRIPTION
Adding this will allow import pixi-spine through bower. After adding this file to repo you'll need to register via:

http://bower.io/docs/creating-packages/#register

Related issue:
pixijs#78