### PR TITLE
Strip extension option when adding texture hash

### DIFF
--- a/src/SpineRuntime/Atlas.js
+++ b/src/SpineRuntime/Atlas.js
@@ -44,10 +44,10 @@ spine.Atlas.prototype = {
         this.regions.push(region);
         return region;
     },
-    addTextureHash: function(textures) {
+    addTextureHash: function(textures, stripExtension) {
         for (var key in textures) {
             if (textures.hasOwnProperty(key)) {
-                this.addTexture(key, textures[key]);
+                this.addTexture(stripExtension ? key.substr(0, key.lastIndexOf('.')) : key, textures[key]);
             }
         }
     },

--- a/src/SpineRuntime/Atlas.js
+++ b/src/SpineRuntime/Atlas.js
@@ -47,7 +47,7 @@ spine.Atlas.prototype = {
     addTextureHash: function(textures, stripExtension) {
         for (var key in textures) {
             if (textures.hasOwnProperty(key)) {
-                this.addTexture(stripExtension ? key.substr(0, key.lastIndexOf('.')) : key, textures[key]);
+                this.addTexture(stripExtension && key.indexOf('.') !== -1 ? key.substr(0, key.lastIndexOf('.')) : key, textures[key]);
             }
         }
     },


### PR DESCRIPTION
If I understand correctly addTextureHash method was added to support external atlases. When using Texture Packer json hash format the image key are samev with extension. Adding stripExtension param to addTextureHash helps parsing this format to work with spine's skeleton file.