### PR TITLE
Replaced ternary operator with conditional

### DIFF
--- a/src/loaders/atlasParser.js
+++ b/src/loaders/atlasParser.js
@@ -27,7 +27,11 @@ var atlasParser = module.exports = function () {
             next();
         }
 
-        var metadataAtlasSuffix = resource.metadata ? resource.metadata.spineAtlasSuffix: '.atlas';
+        var metadataAtlasSuffix = '.atlas';
+        if (resource.metadata && resource.metadata.spineAtlasSuffix) {
+            metadataAtlasSuffix = resource.metadata.spineAtlasSuffix;
+        }
+
         /**
          * use a bit of hackery to load the atlas file, here we assume that the .json, .atlas and .png files
          * that correspond to the spine file are in the same base URL and that the .json and .atlas files


### PR DESCRIPTION
The ternary logic is error prone because `metadata` being defined and not null
doesn't imply that `metadata.spineAtlasSuffix` will be defined and not null.

Replacing ternary with conditional which checks both values fixes the bug.

(The bug I was seeing was a request for a file such as `my_spine_animationundefined` instead of `my_spine_animation.atlas` when `metadata` was defined and not null)