### PR TITLE
Changed shear multiplcation to addition

### DIFF
--- a/src/SpineRuntime/ShearTimeline.js
+++ b/src/SpineRuntime/ShearTimeline.js
@@ -29,8 +29,8 @@ spine.ShearTimeline.prototype = {
 
         if (time >= frames[frames.length - 3])
         { // Time is after last frame.
-            bone.shearX += (bone.data.shearX * frames[frames.length - 2] - bone.shearX) * alpha;
-            bone.shearY += (bone.data.shearY * frames[frames.length - 1] - bone.shearY) * alpha;
+            bone.shearX += (bone.data.shearX + frames[frames.length - 2] - bone.shearX) * alpha;
+            bone.shearY += (bone.data.shearY + frames[frames.length - 1] - bone.shearY) * alpha;
             return;
         }
 


### PR DESCRIPTION
When an animation is complete or we only have a single keyframe of animation
the shear timeline applies the current frame shear to the bones base shear.

When a bone hasn't definied a shear value it defaults to 0, which means this
multiplication is always 0.

Changed multiplication to addition to match the interpolation code below.

We had a spine animation with a single keyframe, however the shear value wasn't being applied correctly. We worked around this by having a 'dummy' second keyframe which meant we were always blending between keyframes with the correct shear value. In this image the box on the left is with 1 keyframe, the box on the right with the dummy second keyframe:
![screen shot 2016-06-10 at 16 22 18](https://cloud.githubusercontent.com/assets/1692194/15969491/372a170c-2f28-11e6-8a46-91550072da89.png)

By changing the multiplication to an addition, the arithmetic matches the interpolation arithmetic and the bug seems fixed, here is the same image from above with this change:
![screen shot 2016-06-10 at 16 23 26](https://cloud.githubusercontent.com/assets/1692194/15969520/58925e04-2f28-11e6-9cde-7d88397266e3.png)

