### PR TITLE
Made AnimationStateListener2 functions optional

### DIFF
--- a/bin/pixi-spine.d.ts
+++ b/bin/pixi-spine.d.ts
@@ -318,13 +318,15 @@ declare namespace pixi_spine.core {
         complete = 4,
         event = 5,
     }
+    type AnimationStateListenerCallback = (entry:TrackEntry)=>void;
+    type AnimationStateListenerEventCallback = (entry:TrackEntry,event:Event)=>void;
     interface AnimationStateListener2 {
-        start(entry: TrackEntry): void;
-        interrupt(entry: TrackEntry): void;
-        end(entry: TrackEntry): void;
-        dispose(entry: TrackEntry): void;
-        complete(entry: TrackEntry): void;
-        event(entry: TrackEntry, event: Event): void;
+        start?:AnimationStateListenerCallback,
+        interrupt?:AnimationStateListenerCallback;
+        end?:AnimationStateListenerCallback;
+        dispose?:AnimationStateListenerCallback;
+        complete?:AnimationStateListenerCallback;
+        event?:AnimationStateListenerEventCallback;
     }
     abstract class AnimationStateAdapter2 implements AnimationStateListener2 {
         start(entry: TrackEntry): void;


### PR DESCRIPTION
First of all, thanks to everyone for all the great work that went into this project.

This is a really basic fix to the ts.d file which makes every function in the animation state listener optional.

I'm not sure if there was an architectural or performance reason for making all the functions mandatory, but it seems that the code checks to see if each function is null anyways, so it *seems* safe.

I also wasn't sure if the ts.d file was generated automatically or not, but I couldn't see anything to indicate as such.

This is my first PR, so be gentle! :)