### PR TITLE
fix number precision problems which prevent some events to get triggered

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -1,5 +1,5 @@
 /// <reference types="pixi.js" />
-
+/// <reference path="polyfills.ts" />
 namespace pixi_spine {
     /* Esoteric Software SPINE wrapper for pixi.js */
     core.Bone.yDown = true;

--- a/src/core/SkeletonJson.ts
+++ b/src/core/SkeletonJson.ts
@@ -656,7 +656,7 @@ namespace pixi_spine.core {
                     let eventMap = map.events[i];
                     let eventData = skeletonData.findEvent(eventMap.name);
                     if (eventData == null) throw new Error("Event not found: " + eventMap.name);
-                    let event = new Event(eventMap.time, eventData);
+                    let event = new Event(Utils.toSinglePrecision(eventMap.time), eventData);
                     event.intValue = this.getValue(eventMap, "int", eventData.intValue);
                     event.floatValue = this.getValue(eventMap, "float", eventData.floatValue);
                     event.stringValue = this.getValue(eventMap, "string", eventData.stringValue);

--- a/src/core/Utils.ts
+++ b/src/core/Utils.ts
@@ -199,6 +199,11 @@ namespace pixi_spine.core {
 		static toFloatArray (array: Array<number>) {
 			return Utils.SUPPORTS_TYPED_ARRAYS ? new Float32Array(array) : array;
 		}
+
+        static toSinglePrecision (value: number) {
+            return Utils.SUPPORTS_TYPED_ARRAYS ? Math.fround(value) : value;
+        }
+
 	}
 
 	export class DebugUtils {

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -1,0 +1,13 @@
+interface Math {
+    fround(n: number): number;
+}
+
+(() => {
+    if (!Math.fround) {
+        Math.fround = Math.fround = (function(array) {
+            return function(x: number) {
+                return array[0] = x, array[0];
+            };
+        })(new Float32Array(1));
+    }
+})();


### PR DESCRIPTION
First of all, thank you for this great project. Myself and my team really love it.

This is to fix a bug I've noticed when putting an event to get triggered at the very end of an animation and when there's support for Float32 Arrays. Basically I've discovered that in that case it can happen that the condition at the line 291 of AnimationState.ts (method `queueEvents`)

`if (event.time > animationEnd) continue;`

passes.

The issue here is that all timelines objects (including the `EventTimeline`) have a property `frames` that is a Float32 Array. 
When setting the timing for each frame with `setFrame` the value / item of the array gets converted in its single precision float representation, which means that for example an event put in the last frame with time: `4.5333 ` gets converted to time: `4.533299922943115`, which makes the condition above true as `animationEnd` is actually the time value from the very last frame, whereas  event.time is the value passed in the constructor when building the whole Spine (`new core.Event(eventMap.time, eventData)`), and that in this case would be 4.5333

To fix this I've used the Math static method `fround` [(see here)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround) which is used to set the time of the event, which means only at the time of the initialisation. Basically we are making consistent the number type (or better, the number representation) so when is time to compare them, the behaviour is always the expected one.

The method is widely supported, but as IE doesn't, I've used the recommended polyfill.
I hope it is all clear.  



