### PR TITLE
Fix PIXI.spine module name

### DIFF
--- a/bin/pixi-spine.d.ts
+++ b/bin/pixi-spine.d.ts
@@ -444,7 +444,7 @@ declare module PIXI.spine.core {
         constructor(name: string);
     }
 }
-declare module pixi_spine.core {
+declare module PIXI.spine.core {
     class ClippingAttachment extends VertexAttachment {
         endSlot: SlotData;
         color: Color;


### PR DESCRIPTION
This type definition was incorrect and would not allow it to be used in a TS project.