### PR TITLE
Clipping no longer breaks when the attachment is keyed

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -355,7 +355,7 @@ namespace pixi_spine {
                         slotContainer.parent = this;
                     }
                 }
-                if (slot.currentGraphics) {
+                if (slot.currentGraphics && slot.attachment) {
                     clippingContainer = slot.clippingContainer;
                     clippingAttachment = slot.attachment as core.ClippingAttachment;
                     clippingContainer.children.length = 0;


### PR DESCRIPTION
This is a new version of the fix from #192 based on @ivanpopelyshev suggestion.  It allows you to attach and detach a clipping attachment during an animation (turning the mask on and off).

I've run some tests on desktop and mobile, and everything seems to work as expected.  My other implementation had an issue I didn't notice until now, and this solves that as well.