### PR TITLE
Make `exporter.js` to be order-insensitivity

### DIFF
--- a/src/exporter.ts
+++ b/src/exporter.ts
@@ -1,0 +1,3 @@
+namespace pixi_spine {
+    (PIXI as any).spine = pixi_spine;
+}

--- a/src/xporter.ts
+++ b/src/xporter.ts
@@ -1,1 +1,0 @@
-(PIXI as any).spine = pixi_spine;


### PR DESCRIPTION
In current version ,  `xporter.js` can't be first one,
 So you have to name it with a strange name.

If we add `namespace pixi_spine {` , whatever the order , it could work correctly.