### PR TITLE
Fixed `setSkin` type annotation

### DIFF
--- a/src/core/Skeleton.ts
+++ b/src/core/Skeleton.ts
@@ -377,7 +377,7 @@ namespace pixi_spine.core {
          * Attachments from the new skin are attached if the corresponding attachment from the old skin was attached. If there was no
          * old skin, each slot's setup mode attachment is attached from the new skin.
          * @param newSkin May be null. */
-        setSkin (newSkin: Skin) {
+        setSkin (newSkin: Skin|null) {
             if (newSkin != null) {
                 if (this.skin != null)
                     newSkin.attachAll(this, this.skin);


### PR DESCRIPTION
The documentation, comments and code all say `newSkin` can be `null` to remove the current skin, but the Typescript annotation on it didn't allow for the value to be `null`.