### PR TITLE
Fixed atlas data reference from 'xhr.responseText' to 'data'

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -82,7 +82,7 @@ namespace pixi_spine {
 
             } else {
                 this.add(resource.name + '_atlas', atlasPath, atlasOptions, function (atlasResource: any) {
-                    createSkeletonWithRawAtlas(atlasResource.xhr.responseText);
+                    createSkeletonWithRawAtlas(atlasResource.data);
                 });
             }
         };


### PR DESCRIPTION
I think that the response of resource-loader is generally stored in 'data'.
> https://github.com/englercj/resource-loader/blob/master/src/Resource.js#L752

It is an obstacle to implementing caching with loader.pre, so I would like to change it if there are no other problems.