### PR TITLE
Added parser method name

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -4,7 +4,7 @@ namespace pixi_spine {
     }
 
     export function atlasParser() {
-        return function (resource: PIXI.loaders.Resource, next: () => any) {
+        return function atlasParser(resource: PIXI.loaders.Resource, next: () => any) {
             // skip if no data, its not json, or it isn't atlas data
             if (!resource.data ||
                 !isJson(resource) ||


### PR DESCRIPTION
I want to find atlasParser from PIXI.loader._afterMiddleware, so I added method name.

before
<img width="330" alt="2018-06-22 10 24 07" src="https://user-images.githubusercontent.com/22776388/41753604-5fb7adb8-7609-11e8-8d31-18ab65517c68.png">

after
<img width="319" alt="2018-06-22 10 25 52" src="https://user-images.githubusercontent.com/22776388/41753611-65c1103c-7609-11e8-951b-97395a78ca54.png">
