### PR TITLE
AnimationState listeners are not added uniquely

### DIFF
--- a/src/core/AnimationState.ts
+++ b/src/core/AnimationState.ts
@@ -563,7 +563,7 @@ namespace pixi_spine.core {
         addListener (listener: AnimationStateListener2) {
             if (listener == null) throw new Error("listener cannot be null.");
             let index = this.listeners.indexOf(listener);
-            if (index >= 0) this.listeners.push(listener);
+            if (index == - 1) this.listeners.push(listener);
         }
 
         /** Removes the listener added with {@link #addListener(AnimationStateListener)}. */

--- a/src/core/AnimationState.ts
+++ b/src/core/AnimationState.ts
@@ -562,7 +562,8 @@ namespace pixi_spine.core {
 
         addListener (listener: AnimationStateListener2) {
             if (listener == null) throw new Error("listener cannot be null.");
-            this.listeners.push(listener);
+            let index = this.listeners.indexOf(listener);
+            if (index >= 0) this.listeners.push(listener);
         }
 
         /** Removes the listener added with {@link #addListener(AnimationStateListener)}. */


### PR DESCRIPTION
I came across a problem in a project where addListener was being called with the same AnimationStateListener2 object.
I would have assumed this would only be registered once, but it seems there is no existing check for that.
Whether or not this is intentional behaviour, I don't know, here's a commit in case it isn't!