### PR TITLE
Set default value to addAnimation 4th parameter

### DIFF
--- a/src/core/AnimationState.ts
+++ b/src/core/AnimationState.ts
@@ -431,13 +431,13 @@ namespace pixi_spine.core {
             return entry;
         }
 
-        addAnimation (trackIndex: number, animationName: string, loop: boolean, delay: number) {
+        addAnimation (trackIndex: number, animationName: string, loop: boolean, delay: number = 0) {
             let animation = this.data.skeletonData.findAnimation(animationName);
             if (animation == null) throw new Error("Animation not found: " + animationName);
             return this.addAnimationWith(trackIndex, animation, loop, delay);
         }
 
-        addAnimationWith (trackIndex: number, animation: Animation, loop: boolean, delay: number) {
+        addAnimationWith (trackIndex: number, animation: Animation, loop: boolean, delay: number = 0) {
             if (animation == null) throw new Error("animation cannot be null.");
 
             let last = this.expandToIndex(trackIndex);


### PR DESCRIPTION
Make this code successfully queue 2 animations : 
animation.state.addAnimation(0, 'walk', false);
animation.state.addAnimation(0, 'run', false);

Without this, we need to set the 4th parameter to 0 or the second animation will never be called : 
animation.state.addAnimation(0, 'walk', false, 0);
animation.state.addAnimation(0, 'run', false, 0);