### PR TITLE
Fix applying flipping for noScale/noScaleOrReflection transform mode.

### DIFF
--- a/src/core/Bone.ts
+++ b/src/core/Bone.ts
@@ -191,14 +191,14 @@ namespace pixi_spine.core {
                     let lb = MathUtils.cosDeg(90 + shearY) * scaleY;
                     let lc = MathUtils.sinDeg(shearX) * scaleX;
                     let ld = MathUtils.sinDeg(90 + shearY) * scaleY;
+                    if (this.data.transformMode != core.TransformMode.NoScaleOrReflection ? pa * pd - pb * pc < 0 : ((this.skeleton.flipX != this.skeleton.flipY) != Bone.yDown)) {
+                        zb = -zb;
+                        zd = -zd;
+                    }
                     m.a = za * la + zb * lc;
                     m.c = za * lb + zb * ld;
                     m.b = zc * la + zd * lc;
                     m.d = zc * lb + zd * ld;
-                    if (this.data.transformMode != TransformMode.NoScaleOrReflection ? pa * pd - pb * pc < 0 : ((this.skeleton.flipX != this.skeleton.flipY) != Bone.yDown)) {
-                        m.c = -m.c;
-                        m.d = -m.d;
-                    }
                     return;
                 }
             }


### PR DESCRIPTION
We're experiencing a problem with disabled scale inheritance in our projects using pixi-spine. Found the issue in the runtimes repo here: https://github.com/EsotericSoftware/spine-runtimes/issues/951.

I've been able to successfully fix the problem by taking the runtime fix (https://github.com/EsotericSoftware/spine-runtimes/commit/d8874cbad689cb6ce96077a2cfc6f1ea935da794), which is just a change that didn't get updated here in pixi-spine.