### PR TITLE
Prevent error for use with custom built versions of PIXI that do not have the Loader module

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -140,6 +140,8 @@ namespace pixi_spine {
         }
     }
 
-    PIXI.loaders.Loader.addPixiMiddleware(atlasParser);
-    PIXI.loader.use(atlasParser());
+    if (PIXI.loaders.Loader) {
+        PIXI.loaders.Loader.addPixiMiddleware(atlasParser);
+        PIXI.loader.use(atlasParser());
+    }
 }


### PR DESCRIPTION
Added a simple 'if' to check if Loaders module is present. Did not alter the unit test as it would require rewriting, can be done on request if needed.