### PR TITLE
Update loaders.ts

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -21,6 +21,9 @@ namespace pixi_spine {
             if (metadataAtlas && metadataAtlas.pages) {
                 //its an atlas!
                 const spineJsonParser = new core.SkeletonJson(new core.AtlasAttachmentLoader(metadataAtlas));
+                if (metadataSkeletonScale) {
+                    spineJsonParser.scale = metadataSkeletonScale;
+                }
                 const skeletonData = spineJsonParser.readSkeletonData(resource.data);
 
                 resource.spineData = skeletonData;


### PR DESCRIPTION
When you load atlas and skeletons separately and load using e.g. {metadata: {spineSkeletonScale: 2.0, spineAtlas: atlas}