### PR TITLE
Add NPM instructions to README (next branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ If you are just including the built files, pixi spine adds itself to a pixi name
 new PIXI.spine.Spine();
 ```
 
+### NPM Install
+
+```bash
+npm install pixi-spine@2.0.0-alpha
+```
+
+The correct way to import pixi-spine is to add it to the namespace.
+
+```js
+import 'pixi-spine'
+```
+
+
 ### Basic example
 
 ```js
@@ -28,8 +41,8 @@ PIXI.loader
 
         // add the animation to the scene and render...
         app.stage.addChild(animation);
-        
-        // run 
+
+        // run
         var animation = new PIXI.spine.Spine(spineBoyData);
         if (animation.state.hasAnimation('run')) {
             // run forever, little boy!
@@ -37,7 +50,7 @@ PIXI.loader
             // dont run too fast
             animation.state.timeScale = 0.1;
         }
-        
+
         app.start();
     });
 ```
@@ -57,7 +70,7 @@ There's "bin/pixi-spine.d.ts" file, you can use it.
 
 ## Spine version
 
-Pixi-spine 1.3.x works ONLY with data exported from Spine 3.5. 
+Pixi-spine 1.3.x works ONLY with data exported from Spine 3.5.
 
 Please enable "beta updates" and re-export everything from the spine editor.
 


### PR DESCRIPTION
It's kind of hard to figure out because of the non-standard import method (just a straight import, no "as" or "from" or anything needed). Also because of the syntax for npm installing from off the master branch. 