### PR TITLE
fix #290

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -202,6 +202,11 @@ namespace pixi_spine {
 
             this.state.update(dt);
             this.state.apply(this.skeleton);
+
+            //check we haven't been destroyed via a spine event callback in state update
+            if(!this.skeleton)
+                return;
+
             this.skeleton.updateWorldTransform();
 
             let slots = this.skeleton.slots;

--- a/src/core/Bone.ts
+++ b/src/core/Bone.ts
@@ -100,9 +100,13 @@ namespace pixi_spine.core {
             let m = this.matrix;
 
             let sx = this.skeleton.scaleX;
-            let sy = this.skeleton.scaleY;
+            let sy = Bone.yDown? -this.skeleton.scaleY : this.skeleton.scaleY;
 
             if (parent == null) { // Root bone.
+                if(Bone.yDown){
+                    rotation = -rotation;
+                    this.arotation = rotation;
+                }
                 let skeleton = this.skeleton;
                 let rotationY = rotation + 90 + shearY;
                 m.a = MathUtils.cosDeg(rotation + shearX) * scaleX * sx;
@@ -111,11 +115,6 @@ namespace pixi_spine.core {
                 m.d = MathUtils.sinDeg(rotationY) * scaleY * sy;
                 m.tx = x * sx + skeleton.x;
                 m.ty = y * sy + skeleton.y;
-
-                if (Bone.yDown) {
-                    m.b = -m.b;
-                    m.d = -m.d;
-                }
                 return;
             }
 
@@ -186,10 +185,6 @@ namespace pixi_spine.core {
                     let lb = MathUtils.cosDeg(90 + shearY) * scaleY;
                     let lc = MathUtils.sinDeg(shearX) * scaleX;
                     let ld = MathUtils.sinDeg(90 + shearY) * scaleY;
-                    if (this.data.transformMode != core.TransformMode.NoScaleOrReflection ? pa * pd - pb * pc < 0 : ((this.skeleton.flipX != this.skeleton.flipY) != Bone.yDown)) {
-                        zb = -zb;
-                        zd = -zd;
-                    }
                     m.a = za * la + zb * lc;
                     m.c = za * lb + zb * ld;
                     m.b = zc * la + zd * lc;
@@ -201,11 +196,6 @@ namespace pixi_spine.core {
             m.c *= sx;
             m.b *= sy;
             m.d *= sy;
-
-            if (Bone.yDown) {
-                m.b = -m.b;
-                m.d = -m.d;
-            }
         }
 
         setToSetupPose() {


### PR DESCRIPTION
This build is working well for me tested across some old and new animations. 

fixes
-rotation flipping on root bone

-removed  'disable inherit scale' check from spine-ts - this seemed to cause some bones with "noScale" transform to get flipped incorrectly.  I've tested various animations with bones inheriting scales, bones with negative scales etc and couldn't see any issues removing those lines, is there a test for that fix?

- in spine update() check after state.apply that everything still ok,  I've got some animations that get destroyed from an animation complete event so this would be useful. 