### PR TITLE
Prevent Exception when no image

### DIFF
--- a/src/core/TextureAtlas.ts
+++ b/src/core/TextureAtlas.ts
@@ -126,6 +126,10 @@ namespace pixi_spine.core {
                             page.uWrap = page.vWrap = TextureWrap.Repeat;
 
                         textureLoader(line, (texture: PIXI.BaseTexture) => {
+                            if (texture === null) {
+                                this.pages.splice(this.pages.indexOf(page), 1);
+                                return callback && callback(null);
+                            }
                             page.baseTexture = texture;
                             if (!texture.hasLoaded) {
                                 texture.width = page.width;

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -78,12 +78,14 @@ namespace pixi_spine {
 
             const createSkeletonWithRawAtlas = function (rawData: string) {
                 new core.TextureAtlas(rawData, adapter, function (spineAtlas) {
-                    const spineJsonParser = new pixi_spine.core.SkeletonJson(new pixi_spine.core.AtlasAttachmentLoader(spineAtlas));
-                    if (metadataSkeletonScale) {
-                        spineJsonParser.scale = metadataSkeletonScale;
+                    if (spineAtlas) {
+                        const spineJsonParser = new pixi_spine.core.SkeletonJson(new pixi_spine.core.AtlasAttachmentLoader(spineAtlas));
+                        if (metadataSkeletonScale) {
+                            spineJsonParser.scale = metadataSkeletonScale;
+                        }
+                        resource.spineData = spineJsonParser.readSkeletonData(resource.data);
+                        resource.spineAtlas = spineAtlas;
                     }
-                    resource.spineData = spineJsonParser.readSkeletonData(resource.data);
-                    resource.spineAtlas = spineAtlas;
                     next();
                 });
             };
@@ -124,7 +126,11 @@ namespace pixi_spine {
                 }
             } else {
                 loader.add(name, url, imageOptions, (resource: PIXI.loaders.Resource) => {
+                  if (!resource.error) {
                     callback(resource.texture.baseTexture);
+                  } else {
+                    callback(null);
+                  }
                 });
             }
         }


### PR DESCRIPTION
The following implementation did not catch the error of image loading.

```
app.loader.add('spine/dragon.json');
app.loader.onError.add((err) => {
  console.log(`onError : ${err.message}`);
});

app.loader.load();
```

Image loading failure results in the following exception error.
<img width="603" alt="スクリーンショット 2019-04-22 18 23 26" src="https://user-images.githubusercontent.com/22776388/56497363-27187900-6538-11e9-8002-b381a5a1e688.png">

In this PR, TextureAtlas loading is canceled when image loading fails.
This enables the application to detect loading failures.
<img width="514" alt="スクリーンショット 2019-04-22 19 45 26" src="https://user-images.githubusercontent.com/22776388/56497689-a78ba980-6539-11e9-807a-5f9f33ee8753.png">


