### PR TITLE
Fixes issue #302, and issue where loaders.ts was failing tsc due to t…

### DIFF
--- a/src/core/AnimationState.ts
+++ b/src/core/AnimationState.ts
@@ -160,8 +160,13 @@ namespace pixi_spine.core {
                 let timelineCount = current.animation.timelines.length;
                 let timelines = current.animation.timelines;
                 if (i == 0 && (mix == 1 || blend == MixBlend.add)) {
-                    for (let ii = 0; ii < timelineCount; ii++)
+                    for (let ii = 0; ii < timelineCount; ii++) {
+                        // Fixes issue #302 on IOS9 where mix, blend sometimes became undefined and caused assets
+                        // to sometimes stop rendering when using color correction, as their RGBA values become NaN.
+                        // (https://github.com/pixijs/pixi-spine/issues/302)
+                        Utils.webkit602BugfixHelper(mix, blend);
                         timelines[ii].apply(skeleton, animationLast, animationTime, events, mix, blend, MixDirection.in);
+                    }
                 } else {
                     let timelineMode = current.timelineMode;
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,6 +1,6 @@
 namespace pixi_spine {
     function isJson(resource: PIXI.loaders.Resource) {
-        return resource.type === PIXI.loaders.Resource.TYPE.JSON;
+        return resource.type === (PIXI.loaders.Resource.TYPE.JSON as any);
     }
 
     export function atlasParser() {
@@ -11,10 +11,10 @@ namespace pixi_spine {
                 !resource.data.bones) {
                 return next();
             }
-            const metadata = resource.metadata || {};
-            const metadataSkeletonScale = metadata ? resource.metadata.spineSkeletonScale : null;
+            const metadata: any = resource.metadata || {};
+            const metadataSkeletonScale = metadata ? (resource.metadata as any).spineSkeletonScale : null;
 
-            const metadataAtlas = metadata ? resource.metadata.spineAtlas : null;
+            const metadataAtlas = metadata ? (resource.metadata as any).spineAtlas : null;
             if (metadataAtlas === false) {
                 return next();
             }
@@ -47,8 +47,8 @@ namespace pixi_spine {
             }
             atlasPath = atlasPath.substr(0, atlasPath.lastIndexOf('.')) + metadataAtlasSuffix;
             // use atlas path as a params. (no need to use same atlas file name with json file name)
-            if (resource.metadata && resource.metadata.spineAtlasFile) {
-                atlasPath = resource.metadata.spineAtlasFile;
+            if (resource.metadata && (resource.metadata as any).spineAtlasFile) {
+                atlasPath = (resource.metadata as any).spineAtlasFile;
             }
 
             //remove the baseUrl
@@ -90,8 +90,8 @@ namespace pixi_spine {
                 });
             };
 
-            if (resource.metadata && resource.metadata.atlasRawData) {
-                createSkeletonWithRawAtlas(resource.metadata.atlasRawData)
+            if (resource.metadata && (resource.metadata as any).atlasRawData) {
+                createSkeletonWithRawAtlas((resource.metadata as any).atlasRawData)
             } else {
                 this.add(resource.name + '_atlas', atlasPath, atlasOptions, function (atlasResource: any) {
                     if (!atlasResource.error) {


### PR DESCRIPTION
Fixes issue #302 on IOS9 where mix, blend sometimes became undefined and caused assets to sometimes stop rendering when using color correction, as their RGBA values become NaN.

Also added casting to any throughout loader.ts as it was failing tsc, meaning i could not do a build.  Nothing is changed, just cases some stuff to make it happy.