### PR TITLE
[fix] hackTexture stopped working after fix #318

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -626,6 +626,7 @@ namespace pixi_spine {
             }
             if (slot.currentSprite && slot.currentSprite.region != region) {
                 this.setSpriteRegion(attachment, slot.currentSprite, region);
+                attachment.region = region;
                 slot.currentSprite.region = region;
             } else if (slot.currentMesh && slot.currentMesh.region != region) {
                 this.setMeshRegion(attachment, slot.currentMesh, region);


### PR DESCRIPTION
In the last published versions our "hacked" textures did not show up. By adding a line I was able to get the old behaviour back.

Right now I set the whole region:
`attachment.region = region;`

Or should I just set the texture (also working..)
`attachment.region.texture = region.texture;`