### PR TITLE
Pin lodash and node types

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "README.md"
   ],
   "devDependencies": {
-    "@types/lodash": "^4.14.108",
+    "@types/lodash": "4.14.159",
+    "@types/node": "13.13.15",
     "checkpack": "^0.3",
     "del": "~2.2.0",
     "glob": "~7.1.1",


### PR DESCRIPTION
Currently, the build fails after a fresh install due to the incompatibility of versions. This PR pins `@types/lodash` and `@types/node` to the latest working versions. The build is broken for `@types/lodash` 4.14.160 and above. Same for  `@types/node` 13.13.16 and above.