### PR TITLE
Move Pixi.js types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "README.md"
   ],
   "devDependencies": {
-    "@types/lodash": "^4.14.108",
+    "@types/lodash": "4.14.159",
+    "@types/node": "13.13.15",
     "checkpack": "^0.3",
     "del": "~2.2.0",
     "glob": "~7.1.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/lodash": "4.14.159",
     "@types/node": "13.13.15",
+    "@types/pixi.js": "^4.8.8",
     "checkpack": "^0.3",
     "del": "~2.2.0",
     "glob": "~7.1.1",
@@ -55,7 +56,5 @@
     "typedoc": "^0.9.0",
     "typescript": "^2.8.3"
   },
-  "dependencies": {
-    "@types/pixi.js": "^4.8.8"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Is there any reason for `@types/pixi.js` to be part of the base dependencies?

If you have custom Pixi.js typings e.g Pixi.js 3 d.ts files in a different scope (not inside @types), they will conflict with the ones required by pixi-spine and cause multiple duplicate identifier errors.

This PR depends on #350. 