### PR TITLE
WIP: Fix checkpack error

### DIFF
--- a/test/checkpack.ts
+++ b/test/checkpack.ts
@@ -3,7 +3,7 @@ import '../bin/pixi-spine.js';
 import ResourceDictionary = PIXI.IResourceDictionary;
 import Loader = PIXI.Loader;
 
-//@../node_modules/pixi.js-legacy/dist/pixi.min.js
+//@../node_modules/pixi.js-legacy/dist/pixi-legacy.min.js
 //@../bin/pixi-spine.js
 
 // remove loader middleware which


### PR DESCRIPTION
The `yarn checkpack` command fails because there is no file named pixi.min.js. Instead, the correct file Is `pixi-legacy.min.js`