### PR TITLE
Update `canvasPadding` property name

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -566,10 +566,8 @@ namespace pixi_spine {
                 new Uint16Array(attachment.triangles),
                 PIXI.DRAW_MODES.TRIANGLES);
 
-            // @ts-ignore
-            if (typeof strip._canvasPadding !== "undefined") {
-                // @ts-ignore
-                strip._canvasPadding = 1.5;
+            if (typeof (strip as any)._canvasPadding !== "undefined") {
+                (strip as any)._canvasPadding = 1.5;
             }
 
             strip.alpha = attachment.color.a;

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -566,8 +566,10 @@ namespace pixi_spine {
                 new Uint16Array(attachment.triangles),
                 PIXI.DRAW_MODES.TRIANGLES);
 
-            if ((strip as any).canvasPadding) {
-                (strip as any).canvasPadding = 1.5;
+            // @ts-ignore
+            if (typeof strip._canvasPadding !== "undefined") {
+                // @ts-ignore
+                strip._canvasPadding = 1.5;
             }
 
             strip.alpha = attachment.color.a;


### PR DESCRIPTION
I'm experiencing a slight a graphical glitch when playing Spine animations which make use of the mesh deform feature in the canvas renderer and have improved it by making this change. From what I can see this property name needs to be updated for newer pixi.js versions? I've included pictures of the graphical glitch and effect of this change.

pixi-spine version: 2.1.9
pixi.js-legacy version: 5.3.3

**Edit: I've just looked into the pixi.js source and see where the canvasPadding global mixin is coming from. So perhaps this is an issue with the canvas renderer rather than this plugin?**

A Spine animation making use of mesh deform without this line applied:

![alt text](https://i.ibb.co/MZYHchs/Capture1.png "Preview")

A Spine animation making use of mesh deform without this line applied:

![alt text](https://i.ibb.co/sFj9n2t/Capture2.png "Preview")