### PR TITLE
BUGFIX: meshes squashed after changing anim state

### DIFF
--- a/src/core/Animation.ts
+++ b/src/core/Animation.ts
@@ -829,7 +829,7 @@ namespace pixi_spine.core {
         }
 
         setAttachment(skeleton: Skeleton, slot: Slot, attachmentName: string) {
-            slot.attachment = attachmentName == null ? null : skeleton.getAttachment(this.slotIndex, attachmentName);
+            slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(this.slotIndex, attachmentName));
         }
     }
 

--- a/src/core/AnimationState.ts
+++ b/src/core/AnimationState.ts
@@ -260,7 +260,7 @@ namespace pixi_spine.core {
                 var slot = slots[i];
                 if (slot.attachmentState == setupState) {
                     var attachmentName = slot.data.attachmentName;
-                    slot.attachment = (attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
+                    slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
                 }
             }
             this.unkeyedState += 2; // Increasing after each use avoids the need to reset attachmentState for every slot.
@@ -378,7 +378,7 @@ namespace pixi_spine.core {
         }
 
         setAttachment (skeleton: Skeleton, slot: Slot, attachmentName: string, attachments: boolean) {
-            slot.attachment = attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName);
+            slot.setAttachment(attachmentName == null ? null : skeleton.getAttachment(slot.data.index, attachmentName));
             if (attachments) slot.attachmentState = this.unkeyedState + AnimationState.CURRENT;
         }
 


### PR DESCRIPTION
I have a bug with squashing mesh attachments when try to change animation state. it reproduced with

> animations made with spine v3.8.99
> pixi.js: 6.0.2
> pixi-spine: >= 2.1.10

So, i compared 2.1.10 and 2.1.11 versions and i think that found and fixed source of this bug.
